### PR TITLE
Update environment variable naming convention

### DIFF
--- a/.document/BACKUP_PLAN.md
+++ b/.document/BACKUP_PLAN.md
@@ -140,3 +140,11 @@ With uri being set, host/port/username/password/database will be ignored. [Read 
 target:
   uri: "mongodb://admin:secret@localhost:27017/test?authSource=admin&ssl=true"
 ```
+
+## Overriding configuration with environment variables
+
+All configuration options can be overridden with environment variables. The format is `PLAN_NAME__SECTION_KEY`.
+
+(all uppercase, double underscore, `__`, as separator between plan name and section key)
+
+For example, to override the `scheduler.cron` option, you can set the `BACKUP_PLAN__SCHEDULER_CRON` environment variable.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
           docker run -d \
           --name mgob \
           --network "host" \
-          -e MONGO-TEST_AZURE_CONNECTIONSTRING="$AZURE_CONNECTIONSTRING" \
+          -e MONGO_TEST__AZURE_CONNECTIONSTRING="$AZURE_CONNECTIONSTRING" \
           -v ${{ github.workspace }}/test/gh-actions:/config \
           -v ${{ github.workspace }}/test/backups:/storage \
           ${{ github.repository }}:${{ env.APP_VERSION }}.${{ github.run_number }}

--- a/pkg/config/plan.go
+++ b/pkg/config/plan.go
@@ -206,7 +206,8 @@ func LoadPlans(dir string) ([]Plan, error) {
 func setupViperEnv(planName string) {
 	viper.SetConfigType("yaml")
 	// set upper case plan name as env prefix
-	viper.SetEnvPrefix(strings.ToUpper(planName))
+	envPrefix := strings.ReplaceAll(planName, "-", "_")
+	viper.SetEnvPrefix(envPrefix + "_") // will be uppercased automatically
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 }

--- a/pkg/config/plan_test.go
+++ b/pkg/config/plan_test.go
@@ -21,7 +21,7 @@ func TestLoadPlan(t *testing.T) {
 	// set env var for test
 	testConnectionString := "test-connetion-string"
 	testPlanName := "mongo-test"
-	os.Setenv(fmt.Sprintf("%s_%s_%s", strings.ToUpper(testPlanName), "AZURE", "CONNECTIONSTRING"), testConnectionString)
+	os.Setenv(fmt.Sprintf("%s__%s_%s", strings.ToUpper(strings.Replace(testPlanName, "-", "_", -1)), "AZURE", "CONNECTIONSTRING"), testConnectionString)
 	dir := getDir(t)
 	plan, err := LoadPlan(dir, testPlanName)
 
@@ -41,7 +41,7 @@ func TestLoadPlans(t *testing.T) {
 	// set env var for test
 	testConnectionString := "test-connetion-string"
 	testPlanName := "mongo-test"
-	os.Setenv(fmt.Sprintf("%s_%s_%s", strings.ToUpper(testPlanName), "AZURE", "CONNECTIONSTRING"), testConnectionString)
+	os.Setenv(fmt.Sprintf("%s__%s_%s", strings.ToUpper(strings.Replace(testPlanName, "-", "_", -1)), "AZURE", "CONNECTIONSTRING"), testConnectionString)
 	dir := getDir(t)
 
 	plans, err := LoadPlans(dir)


### PR DESCRIPTION
## Breaking Change
In this PR, there is a breaking change because the original solution doesn't work in real environment.

In bash, it is not possible to use "-" as environment name, so the new rules are

* - will turn into _
* double __ will be used as a separator 

ex: 
 `plan-name-with-dash`

the env will be `PLAN_NAME_WITH_DASH__SECTION_PROPERTY` 


## Special Note

The secret needs to be in the config with a placeholder 

eg:

```yaml
target:
  password: "load from env"
```
 Viper has a issue to handle this https://github.com/spf13/viper/issues/761

It can handle it in version 1.8.1 but it also introduce another issue.

so we stick with version 1.6.0 and see what to do next.