### PR TITLE
feat: pass additional optional params to mongorestore

### DIFF
--- a/.document/BACKUP_PLAN.md
+++ b/.document/BACKUP_PLAN.md
@@ -26,6 +26,7 @@ validation:
     port: 27017
     noGzip: false
     database: test_restore # Database name for restore operation
+    params: "--bypassDocumentValidation" # Additional mongorestore params, leave blank if not needed
 # Encryption (optional)
 encryption:
   # At the time being, only gpg asymmetric encryption is supported

--- a/pkg/backup/utils_test.go
+++ b/pkg/backup/utils_test.go
@@ -20,10 +20,11 @@ func Test_BuildRestoreCmd_Different_Name(t *testing.T) {
 		Host:     "localhost",
 		Port:     27017,
 		Database: "test-restore",
+		Params:   "--bypassDocumentValidation",
 	}
 
 	dumpCmd := BuildRestoreCmd("test.gz", target, restore)
-	assert.Equal(t, dumpCmd, `mongorestore --archive=test.gz --gzip --host localhost --port 27017 --nsInclude test.* --nsFrom test.* --nsTo test-restore.* `)
+	assert.Equal(t, dumpCmd, `mongorestore --archive=test.gz --gzip --host localhost --port 27017 --nsInclude test.* --bypassDocumentValidation --nsFrom test.* --nsTo test-restore.* `)
 }
 
 func Test_BuildRestoreCmd_Same_Name(t *testing.T) {
@@ -39,10 +40,11 @@ func Test_BuildRestoreCmd_Same_Name(t *testing.T) {
 		Host:     "localhost",
 		Port:     27017,
 		Database: "test",
+		Params:   "--bypassDocumentValidation",
 	}
 
 	dumpCmd := BuildRestoreCmd("test.gz", target, restore)
-	assert.Equal(t, dumpCmd, `mongorestore --archive=test.gz --gzip --host localhost --port 27017 --nsInclude test.* `)
+	assert.Equal(t, dumpCmd, `mongorestore --archive=test.gz --gzip --host localhost --port 27017 --nsInclude test.* --bypassDocumentValidation `)
 }
 
 func Test_BuildDumpCmd_no_uri(t *testing.T) {


### PR DESCRIPTION
Hi!

I have a need to pass additional parameters (like `--bypassDocumentValidation` ) to the mongorestore command in the same manner like using `target.params` to pass additional parameters to the mongodump cmd.

I've made this small PR to implement this feature.

Thanks!