### PR TITLE
Add optional S3 sync mode

### DIFF
--- a/.document/BACKUP_PLAN.md
+++ b/.document/BACKUP_PLAN.md
@@ -45,6 +45,8 @@ s3:
   # accessKey and secretKey are optional for AWS, if your Docker image has awscli
   accessKey: "Q3AM3UQ867SPQQA43P2F"
   secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+  # When true, mirror the plan's local storage directory to the bucket (requires storage_path and retention > 0)
+  sync: false
   # Optional, only used for AWS (when awscli is present)
   # The customer-managed AWS Key Management  Service (KMS) key ID that should be used to
   # server-side encrypt the backup in S3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,6 +218,13 @@ jobs:
             exit 1
           fi
 
+      - name: Verify MinIO mirror sync
+        run: |
+          if ! grep -q "mirror --remove" logs.txt; then
+            echo "MinIO mirror sync verification failed"
+            exit 1
+          fi          
+
       - name: Verify mgob cloud backup
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Verify MinIO mirror sync
         run: |
-          if ! grep -q "mirror --remove" logs.txt; then
+          if ! grep -q "mirror" logs.txt; then
             echo "MinIO mirror sync verification failed"
             exit 1
           fi          

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - New Helm Chart with enhanced metrics, liveness probe, and other features
 - Multiple Docker image releases catering to different backup solutions
 - Option to skip local backup when retention is set to 0 ([#42](https://github.com/maxisam/mgob/pull/42), Credit: @aneagoe)
+- Optional S3 sync mode to mirror the retained local backups to object storage
 - On-demand restore API
 - Load config from environment variables to override config file. syntax: `PLAN_ID__KEY_PROPERTY` (e.g. `mongo_test__SMTP_SERVER=smtp.company.com`)
 

--- a/charts/mgob/README.md
+++ b/charts/mgob/README.md
@@ -1,6 +1,6 @@
 # mgob
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.20](https://img.shields.io/badge/AppVersion-2.0.20-informational?style=flat-square)
+![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.20](https://img.shields.io/badge/AppVersion-2.0.20-informational?style=flat-square)
 
 A Helm chart for Mgob,  MongoDB dockerized backup agent.
 Runs scheduled backups with retention, S3 & SFTP upload, notifications, instrumentation with Prometheus and more.

--- a/charts/mgob/values.yaml
+++ b/charts/mgob/values.yaml
@@ -106,6 +106,8 @@ config: {}
 #        bucket: "backup"
 #        accessKey: "Q3AM3UQ867SPQQA43P2F"
 #        secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+#        # When enabled, mirror the local storage directory to the bucket (requires storagePath and retention > 0)
+#        sync: false
 #        createbucketifneeded: false
 #        # For Minio and AWS use S3v4 for GCP use S3v2
 #        api: "S3v4"

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -57,6 +57,11 @@ func Run(plan config.Plan, conf *config.AppConfig, modules *config.ModuleConfig)
 		}
 	}
 
+	planDir := ""
+	if conf.StoragePath != "" {
+		planDir = filepath.Join(conf.StoragePath, plan.Name)
+	}
+
 	if conf.StoragePath != "" && plan.Scheduler.Retention != 0 {
 		localBackupOutput, err := localBackup(file, conf.StoragePath, mlog, plan)
 		if err != nil {
@@ -76,7 +81,7 @@ func Run(plan config.Plan, conf *config.AppConfig, modules *config.ModuleConfig)
 	}
 
 	if plan.S3 != nil {
-		s3Output, err := s3Upload(file, plan, conf.UseAwsCli)
+		s3Output, err := s3Upload(file, plan, conf.UseAwsCli, planDir)
 		if err != nil {
 			return res, err
 		} else {

--- a/pkg/config/plan.go
+++ b/pkg/config/plan.go
@@ -73,6 +73,7 @@ type S3 struct {
 	KmsKeyId             string `yaml:"kmsKeyId"`
 	StorageClass         string `yaml:"storageClass" validate:"omitempty,oneof=STANDARD REDUCED_REDUNDANCY STANDARD_IA ONE-ZONE_IA INTELLIGENT_TIERING GLACIER DEEP_ARCHIVE"`
 	CreateBucketIfNeeded bool   `yaml:"createbucketifneeded"`
+	Sync                 bool   `yaml:"sync"`
 }
 
 type GCloud struct {

--- a/test/gh-actions/mongo-test.yml
+++ b/test/gh-actions/mongo-test.yml
@@ -20,6 +20,7 @@ s3:
   accessKey: "AKIAIOSFODNN7EXAMPLE"
   secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   api: "S3v4"
+  sync: true  
 gcloud:
   bucket: "maxisam-mgob"
   keyFilePath: "/config/gcloud.json"


### PR DESCRIPTION
## Summary
- add a `sync` flag to the S3 configuration so plans can mirror their retained local backups to object storage
- teach the S3 uploader to use either `aws s3 sync` or `mc mirror` when the flag is enabled, reusing the plan storage directory
- document the new option in the backup plan reference, Helm values, and README

