### PR TITLE
Update MinIO client commands and yq installation method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           sleep 10
           sudo curl -s -o /usr/bin/mc https://dl.minio.io/client/mc/release/linux-amd64/mc
           sudo chmod u+x /usr/bin/mc
-          sudo mc config host add local http://127.0.0.1:9000 ${{ env.MINIO_ROOT_USER }} ${{ env.MINIO_ROOT_PASSWORD }} --api S3v4
+          sudo mc alias set local http://127.0.0.1:9000 ${{ env.MINIO_ROOT_USER }} ${{ env.MINIO_ROOT_PASSWORD }} --api S3v4
           sudo mc mb local/backup
 
       - name: Setup SFTP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Install yq and remove gcloud section if event is pull_request
         if: github.event_name == 'pull_request'
         run: |
-          sudo add-apt-repository ppa:rmescandon/yq -y
-          sudo apt-get install -y yq
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
           yq eval 'del(.gcloud)' -i test/gh-actions/mongo-test.yml
 
       - name: Run Mgob image

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ backend:
 	    -e "MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE" \
 	    -e "MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
 	    minio/minio server /export
-	@mc config host add local http://localhost:20099 \
+	@mc alias set local http://localhost:20099 \
 	    AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY --api S3v4
 	@sleep 5
 	@mc mb local/backup


### PR DESCRIPTION
Revise the installation method for yq to use wget instead of the apt repository. Update MinIO client commands to utilize 'mc alias set' instead of 'mc config host add' for improved compatibility and functionality.