### PR TITLE
feat: MinIO mirror sync

### DIFF
--- a/.document/BACKUP_PLAN.md
+++ b/.document/BACKUP_PLAN.md
@@ -54,6 +54,9 @@ s3:
   #     ZONE_IA  |  INTELLIGENT_TIERING  |  GLACIER | DEEP_ARCHIVE.
   # Defaults to 'STANDARD'
   #storageClass: STANDARD
+  # When true, use `mc mirror --remove` to keep the bucket in sync with the local plan directory.
+  # Requires a configured storagePath and scheduler retention greater than zero so the plan directory exists.
+  sync: false
   # For Minio and AWS use S3v4 for GCP use S3v2
   api: "S3v4"
   # optional, automatically create the bucket if it does not exist yet
@@ -109,6 +112,10 @@ team:
   warnOnly: false
   themeColor: "#f6c344"
 ```
+
+### S3 sync mode
+
+Setting `s3.sync: true` switches the upload behavior from individual `mc cp` commands to `mc mirror --remove`, keeping the remote bucket aligned with the plan's local storage directory. To avoid mirror failures, ensure the mgob application is configured with a `storagePath` and that `scheduler.retention` remains greater than zero so the directory exists when the mirror runs.
 
 ## Database connection (target)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,8 @@ jobs:
           sudo chmod u+x /usr/bin/mc
           sudo mc config host add local http://127.0.0.1:9000 ${{ env.MINIO_ROOT_USER }} ${{ env.MINIO_ROOT_PASSWORD }} --api S3v4
           sudo mc mb local/backup
+          echo 'mirror-sentinel' | sudo tee /tmp/minio-sentinel >/dev/null
+          sudo mc cp /tmp/minio-sentinel local/backup/mirror-sentinel.txt
 
       - name: Setup SFTP
         run: |
@@ -217,6 +219,15 @@ jobs:
             echo "SFTP integration test failed"
             exit 1
           fi
+
+      - name: Verify MinIO mirror sync
+        run: |
+          if sudo mc ls local/backup | grep -q "mirror-sentinel.txt"; then
+            echo "MinIO mirror sync verification failed: sentinel object still present"
+            sudo mc ls local/backup
+            exit 1
+          fi
+          echo "MinIO mirror sync removed sentinel object."
 
       - name: Verify mgob cloud backup
         if: github.event_name == 'workflow_dispatch'

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -76,7 +76,7 @@ func Run(plan config.Plan, conf *config.AppConfig, modules *config.ModuleConfig)
 	}
 
 	if plan.S3 != nil {
-		s3Output, err := s3Upload(file, plan, conf.UseAwsCli)
+		s3Output, err := s3Upload(file, plan, conf.UseAwsCli, conf.StoragePath)
 		if err != nil {
 			return res, err
 		} else {

--- a/pkg/backup/s3.go
+++ b/pkg/backup/s3.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -13,7 +14,7 @@ import (
 	"github.com/stefanprodan/mgob/pkg/config"
 )
 
-func s3Upload(file string, plan config.Plan, useAwsCli bool) (string, error) {
+func s3Upload(file string, plan config.Plan, useAwsCli bool, storagePath string) (string, error) {
 
 	s3Url, err := url.Parse(plan.S3.URL)
 
@@ -25,7 +26,7 @@ func s3Upload(file string, plan config.Plan, useAwsCli bool) (string, error) {
 		return awsUpload(file, plan)
 	}
 
-	return minioUpload(file, plan)
+	return minioUpload(file, plan, storagePath)
 }
 
 func awsUpload(file string, plan config.Plan) (string, error) {
@@ -75,7 +76,7 @@ func awsUpload(file string, plan config.Plan) (string, error) {
 	return strings.Replace(output, "\n", " ", -1), nil
 }
 
-func minioUpload(file string, plan config.Plan) (string, error) {
+func minioUpload(file string, plan config.Plan, storagePath string) (string, error) {
 
 	register := fmt.Sprintf("mc config host add %v %v %v %v --api %v",
 		plan.Name, plan.S3.URL, plan.S3.AccessKey, plan.S3.SecretKey, plan.S3.API)
@@ -94,6 +95,14 @@ func minioUpload(file string, plan config.Plan) (string, error) {
 		if err != nil {
 			return "", err
 		}
+	}
+
+	if plan.S3.Sync {
+		syncOutput, err := minioMirror(plan, storagePath, time.Duration(plan.Scheduler.Timeout)*time.Minute)
+		if err != nil {
+			return "", err
+		}
+		return syncOutput, nil
 	}
 
 	fileName := filepath.Base(file)
@@ -116,6 +125,40 @@ func minioUpload(file string, plan config.Plan) (string, error) {
 	}
 
 	return strings.Replace(output, "\n", " ", -1), nil
+}
+
+func minioMirror(plan config.Plan, storagePath string, timeout time.Duration) (string, error) {
+	if storagePath == "" {
+		return "", errors.Errorf("S3 sync requested but storage path is empty for plan %v", plan.Name)
+	}
+
+	planDir := filepath.Join(storagePath, plan.Name)
+	if _, err := os.Stat(planDir); err != nil {
+		return "", errors.Wrapf(err, "S3 sync failed, could not access plan directory %v", planDir)
+	}
+
+	mirrorCmd := fmt.Sprintf("mc --quiet mirror --remove %v %v/%v", planDir, plan.Name, plan.S3.Bucket)
+
+	result, err := sh.Command("/bin/sh", "-c", mirrorCmd).SetTimeout(timeout).CombinedOutput()
+	output := ""
+	if len(result) > 0 {
+		output = strings.Replace(string(result), "\n", " ", -1)
+	}
+
+	message := fmt.Sprintf("mirror --remove %v %v/%v", planDir, plan.Name, plan.S3.Bucket)
+	if output != "" {
+		message = fmt.Sprintf("%s %s", message, output)
+	}
+
+	if err != nil {
+		return "", errors.Wrapf(err, "S3 syncing %v to %v/%v failed %v", planDir, plan.Name, plan.S3.Bucket, output)
+	}
+
+	if strings.Contains(output, "<ERROR>") {
+		return "", errors.Errorf("S3 sync failed %v", output)
+	}
+
+	return message, nil
 }
 
 func minioCreateBucket(plan config.Plan) error {

--- a/pkg/config/plan.go
+++ b/pkg/config/plan.go
@@ -73,6 +73,7 @@ type S3 struct {
 	KmsKeyId             string `yaml:"kmsKeyId"`
 	StorageClass         string `yaml:"storageClass" validate:"omitempty,oneof=STANDARD REDUCED_REDUNDANCY STANDARD_IA ONE-ZONE_IA INTELLIGENT_TIERING GLACIER DEEP_ARCHIVE"`
 	CreateBucketIfNeeded bool   `yaml:"createbucketifneeded"`
+	Sync                 bool   `yaml:"sync"`
 }
 
 type GCloud struct {

--- a/test/config/mongo-test.yml
+++ b/test/config/mongo-test.yml
@@ -14,3 +14,4 @@ s3:
   accessKey: "Q3AM3UQ867SPQQA43P2F"
   secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
   api: "S3v4"
+  sync: true

--- a/test/gh-actions/mongo-test.yml
+++ b/test/gh-actions/mongo-test.yml
@@ -20,6 +20,7 @@ s3:
   accessKey: "AKIAIOSFODNN7EXAMPLE"
   secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   api: "S3v4"
+  sync: true
 gcloud:
   bucket: "maxisam-mgob"
   keyFilePath: "/config/gcloud.json"

--- a/test/travis/mongo-test.yml
+++ b/test/travis/mongo-test.yml
@@ -12,3 +12,4 @@ s3:
   accessKey: "AKIAIOSFODNN7EXAMPLE"
   secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   api: "S3v4"
+  sync: true

--- a/test/unit-test/mongo-test.yml
+++ b/test/unit-test/mongo-test.yml
@@ -20,6 +20,7 @@ s3:
   accessKey: "AKIAIOSFODNN7EXAMPLE"
   secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   api: "S3v4"
+  sync: true
 gcloud:
   bucket: "maxisam-mgob"
   keyFilePath: "/config/gcloud.json"


### PR DESCRIPTION
## Summary
- seed the MinIO bucket with a sentinel object before running tests so mirror runs can demonstrate removal
- update the CI verification step to assert the sentinel was deleted, confirming `mc mirror --remove`
- document the configuration prerequisites for enabling S3 sync so operators know when mirrors will succeed
